### PR TITLE
Fix compilation on GHC 7.10.1.

### DIFF
--- a/src/KMC/FSTConstruction.hs
+++ b/src/KMC/FSTConstruction.hs
@@ -6,7 +6,7 @@ module KMC.FSTConstruction
 where
 
 import           Control.Monad.State
-import           Data.Monoid
+import           Data.Monoid (Monoid)
 import qualified Data.Set as S
 
 import           KMC.Expression


### PR DESCRIPTION
In newer versions of base, Data.Monoid exports a constructor Alt,
which causes a conflict.